### PR TITLE
Add example of Kaniko with file system caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,29 @@ As soon as you intend to use your images in production we recommend build layer 
 
  * Faster builds
  * Less space used for image registry storage
- * Faster pulls at upgrade
+ * Faster pulls for new revisions
 
-Like with Docker the advantages depend on Dockerfile design,
-but anyhow Build Pipeline manifests can be used to set up Kaniko caching.
+The advantages depend on Dockerfile design,
+but anyhow we recommend that all Build tasks with Kaniko use caching.
 
-The example uses file system caching and sets up one [pvc]() per namespace.
+The example uses file system caching and sets up one [pvc](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims) per namespace.
 This means that you can run only one build at a time per namespace,
 as the build pod needs to mount the volume.
 
 Caching between different builds is often not desirable but can have all the above advantages,
 in particular if you reuse Dockerfiles.
 Pay attention to the `claimName` in your runs, and edit at will.
+
+To run the example apply a [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/)
+such as [our gke example](./caching-kaniko-example/storageclassl-gke.yaml).
+We recommend that you use one with `allowVolumeExpansion: true`
+because you'll probably want to keep these caches long term. After that:
+
+```
+kubectl apply -f caching-kaniko-build.yaml
+kubectl apply -f caching-kaniko-example/pvc.yaml
+kubectl apply -f caching-kaniko-example/run.yaml
+```
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,25 @@ kubectl apply -f azure-example/resources.yaml
 kubectl apply -f azure-example/taskrun.yaml
 ```
 
+## Kaniko build caching
+
+As soon as you intend to use your images in production we recommend build layer caching. Advantages:
+
+ * Faster builds
+ * Less space used for image registry storage
+ * Faster pulls at upgrade
+
+Like with Docker the advantages depend on Dockerfile design,
+but anyhow Build Pipeline manifests can be used to set up Kaniko caching.
+
+The example uses file system caching and sets up one [pvc]() per namespace.
+This means that you can run only one build at a time per namespace,
+as the build pod needs to mount the volume.
+
+Caching between different builds is often not desirable but can have all the above advantages,
+in particular if you reuse Dockerfiles.
+Pay attention to the `claimName` in your runs, and edit at will.
+
 ## Support
 
 We would love your feedback on this project so don't hesitate to let us know what is wrong and how we could improve it, just file an [issue](https://github.com/triggermesh/charts/issues/new)

--- a/caching-kaniko-build.yaml
+++ b/caching-kaniko-build.yaml
@@ -1,0 +1,43 @@
+# Copyright 2018 TriggerMesh, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: pipeline.knative.dev/v1alpha1
+kind: Task
+metadata:
+  name: caching-kaniko
+spec:
+  inputs:
+    resources:
+    - name: workspace
+      type: git
+    params:
+    - name: pathToDockerFile
+      description: The path to the dockerfile to build
+      default: /workspace/Dockerfile
+    - name: pathToContext
+      description: The build context used by Kaniko (https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts)
+      default: /workspace
+  outputs:
+    resources:
+    - name: builtImage
+      type: image
+  steps:
+  - name: build-and-push
+    image: gcr.io/kaniko-project/executor
+    command:
+    - /kaniko/executor
+    args:
+    - --dockerfile=${inputs.params.pathToDockerFile}
+    - --destination=${outputs.resources.builtImage.url}
+    - --context=${inputs.params.pathToContext}

--- a/caching-kaniko-build.yaml
+++ b/caching-kaniko-build.yaml
@@ -41,3 +41,8 @@ spec:
     - --dockerfile=${inputs.params.pathToDockerFile}
     - --destination=${outputs.resources.builtImage.url}
     - --context=${inputs.params.pathToContext}
+    - --cache=true
+    - --cache-dir=/cache
+  volumeMounts:
+  - name: kaniko-cache
+    mountPath: /cache

--- a/caching-kaniko-example/Dockerfile
+++ b/caching-kaniko-example/Dockerfile
@@ -1,5 +1,5 @@
 FROM busybox
-RUN touch timestamp1
-# You don't want this build step to take one minute every time
+RUN date | tee timestamp1
+# This is the slow build step that you'd want cached
 RUN sleep 60
-RUN touch timestamp2
+RUN date | tee timestamp2

--- a/caching-kaniko-example/Dockerfile
+++ b/caching-kaniko-example/Dockerfile
@@ -1,0 +1,5 @@
+FROM busybox
+RUN touch timestamp1
+# You don't want this build step to take one minute every time
+RUN sleep 60
+RUN touch timestamp2

--- a/caching-kaniko-example/pvc.yaml
+++ b/caching-kaniko-example/pvc.yaml
@@ -7,4 +7,5 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
+      # If your storageclass supports allowVolumeExpansion you can increase this at any time
       storage: 1Gi

--- a/caching-kaniko-example/pvc.yaml
+++ b/caching-kaniko-example/pvc.yaml
@@ -1,0 +1,10 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: kaniko-cache
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/caching-kaniko-example/run.yaml
+++ b/caching-kaniko-example/run.yaml
@@ -13,7 +13,7 @@ spec:
 apiVersion: pipeline.knative.dev/v1alpha1
 kind: PipelineResource
 metadata:
-  name: caching-kaniko-image
+  name: caching-kaniko-image  
 spec:        
   type: image
   params:
@@ -48,3 +48,7 @@ spec:
     - name: builtImage
       resourceRef:
         name: caching-kaniko-image
+  volumes:
+  - name: kaniko-cache
+    persistentVolumeClaim:
+      claimName: kaniko-cache

--- a/caching-kaniko-example/run.yaml
+++ b/caching-kaniko-example/run.yaml
@@ -1,0 +1,50 @@
+apiVersion: pipeline.knative.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: caching-kaniko-git
+spec:
+  type: git
+  params:
+  - name: url
+    value: https://github.com/triggermesh/pipeline-tasks
+  - name: revision
+    value: build-caching
+---        
+apiVersion: pipeline.knative.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: caching-kaniko-image
+spec:        
+  type: image
+  params:
+  - name: url
+    value: knative.registry.svc.cluster.local/knative-training/caching-kaniko:latest
+---
+apiVersion: pipeline.knative.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: caching-kaniko
+spec:
+  taskRef:
+    name: caching-kaniko
+  trigger:
+    triggerRef:
+      type: manual
+  results:
+    type: 'gcs'
+    url: 'gcs://somebucket/results/logs'
+  inputs:
+    resources:
+    - name: workspace
+      resourceRef:
+        name: caching-kaniko-git
+    params:
+    - name: pathToDockerFile
+      value: Dockerfile
+    - name: pathToContext
+      value: /workspace/caching-kaniko-example
+  outputs:
+    resources:
+    - name: builtImage
+      resourceRef:
+        name: caching-kaniko-image

--- a/caching-kaniko-example/storageclassl-gke.yaml
+++ b/caching-kaniko-example/storageclassl-gke.yaml
@@ -1,0 +1,9 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: kaniko-cache
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+reclaimPolicy: Delete
+allowVolumeExpansion: true


### PR DESCRIPTION
The intended effect is:

First build:

```
$ kubectl logs -f caching-kaniko-pod-afe83f -c build-step-build-and-push
INFO[0000] Downloading base image busybox               
ERROR: logging before flag.Parse: E1205 07:28:50.143880       8 metadata.go:142] while reading 'google-dockercfg' metadata: http status code: 404 while fetching url http://metadata.google.internal./computeMetadata/v1/instance/attributes/google-dockercfg
ERROR: logging before flag.Parse: E1205 07:28:50.149435       8 metadata.go:159] while reading 'google-dockercfg-url' metadata: http status code: 404 while fetching url http://metadata.google.internal./computeMetadata/v1/instance/attributes/google-dockercfg-url
2018/12/05 07:28:50 No matching credentials were found, falling back on anonymous
WARN[0001] Error while retrieving image from cache: getting image from path: open /cache/sha256:915f390a8912e16d4beb8689720a17348f3f6d1a7b659697df850ab625ea29d5: no such file or directory 
INFO[0001] Downloading base image busybox               
2018/12/05 07:28:51 No matching credentials were found, falling back on anonymous
INFO[0002] Checking for cached layer knative.registry.svc.cluster.local/knative-training/caching-kaniko/cache:553f18e617d99a4f8025512cb59a5a508c65e9dc3cdd33214c8e74cbd5e8ca48... 
2018/12/05 07:28:52 No matching credentials were found, falling back on anonymous
INFO[0002] No cached layer found for cmd RUN date | tee timestamp1 
INFO[0002] Unpacking rootfs as cmd RUN date | tee timestamp1 requires it. 
INFO[0002] Taking snapshot of full filesystem...        
INFO[0002] Skipping paths under /builder/home, as it is a whitelisted directory 
INFO[0002] Skipping paths under /dev, as it is a whitelisted directory 
INFO[0002] Skipping paths under /kaniko, as it is a whitelisted directory 
INFO[0002] Skipping paths under /proc, as it is a whitelisted directory 
INFO[0002] Skipping paths under /sys, as it is a whitelisted directory 
INFO[0002] Skipping paths under /tools, as it is a whitelisted directory 
INFO[0002] Skipping paths under /var/run, as it is a whitelisted directory 
INFO[0002] Skipping paths under /workspace, as it is a whitelisted directory 
INFO[0003] RUN date | tee timestamp1                    
INFO[0003] cmd: /bin/sh                                 
INFO[0003] args: [-c date | tee timestamp1]             
Wed Dec  5 07:28:53 UTC 2018
INFO[0003] Taking snapshot of full filesystem...        
INFO[0003] Skipping paths under /builder/home, as it is a whitelisted directory 
INFO[0003] Skipping paths under /dev, as it is a whitelisted directory 
INFO[0003] Skipping paths under /kaniko, as it is a whitelisted directory 
INFO[0003] Skipping paths under /proc, as it is a whitelisted directory 
INFO[0003] Skipping paths under /sys, as it is a whitelisted directory 
INFO[0003] Skipping paths under /tools, as it is a whitelisted directory 
INFO[0003] Skipping paths under /var/run, as it is a whitelisted directory 
INFO[0003] Skipping paths under /workspace, as it is a whitelisted directory 
INFO[0004] RUN sleep 60                                 
INFO[0004] cmd: /bin/sh                                 
INFO[0004] args: [-c sleep 60]                          
INFO[0004] Pushing layer knative.registry.svc.cluster.local/knative-training/caching-kaniko/cache:553f18e617d99a4f8025512cb59a5a508c65e9dc3cdd33214c8e74cbd5e8ca48 to cache now 
2018/12/05 07:28:55 pushed blob sha256:4d6e8a4e0c046d20fba00fcad83817c28134daa77dd29c31d125c3e385464a9c
2018/12/05 07:28:55 pushed blob sha256:c5cc522d2cdad2ae43912e6490527f2dee0fd5fd982683963d77d83c629c7a89
2018/12/05 07:28:55 knative.registry.svc.cluster.local/knative-training/caching-kaniko/cache:553f18e617d99a4f8025512cb59a5a508c65e9dc3cdd33214c8e74cbd5e8ca48: digest: sha256:5a6cd9f6f70439b3c5dc6e0615d266cf44ba9de8a76dbdb0ce465156b39a5d8c size: 424
INFO[0064] Taking snapshot of full filesystem...        
INFO[0064] Skipping paths under /builder/home, as it is a whitelisted directory 
INFO[0064] Skipping paths under /dev, as it is a whitelisted directory 
INFO[0064] Skipping paths under /kaniko, as it is a whitelisted directory 
INFO[0064] Skipping paths under /proc, as it is a whitelisted directory 
INFO[0064] Skipping paths under /sys, as it is a whitelisted directory 
INFO[0064] Skipping paths under /tools, as it is a whitelisted directory 
INFO[0064] Skipping paths under /var/run, as it is a whitelisted directory 
INFO[0064] Skipping paths under /workspace, as it is a whitelisted directory 
INFO[0066] No files were changed, appending empty layer to config. No layer added to image. 
INFO[0066] RUN date | tee timestamp2                    
INFO[0066] cmd: /bin/sh                                 
INFO[0066] args: [-c date | tee timestamp2]             
Wed Dec  5 07:29:56 UTC 2018
INFO[0066] Taking snapshot of full filesystem...        
INFO[0066] Pushing layer knative.registry.svc.cluster.local/knative-training/caching-kaniko/cache:b52d8630301f1f14d786168567c47278f7ff1f25b0c6f1eb199e3304f7e6c6c4 to cache now 
ERROR: logging before flag.Parse: E1205 07:29:56.199737       8 metadata.go:142] while reading 'google-dockercfg' metadata: http status code: 404 while fetching url http://metadata.google.internal./computeMetadata/v1/instance/attributes/google-dockercfg
ERROR: logging before flag.Parse: E1205 07:29:56.206985       8 metadata.go:159] while reading 'google-dockercfg-url' metadata: http status code: 404 while fetching url http://metadata.google.internal./computeMetadata/v1/instance/attributes/google-dockercfg-url
INFO[0066] Skipping paths under /builder/home, as it is a whitelisted directory 
INFO[0066] Skipping paths under /dev, as it is a whitelisted directory 
INFO[0066] Skipping paths under /kaniko, as it is a whitelisted directory 
INFO[0066] Skipping paths under /proc, as it is a whitelisted directory 
INFO[0066] Skipping paths under /sys, as it is a whitelisted directory 
INFO[0066] Skipping paths under /tools, as it is a whitelisted directory 
INFO[0066] Skipping paths under /var/run, as it is a whitelisted directory 
INFO[0066] Skipping paths under /workspace, as it is a whitelisted directory 
2018/12/05 07:29:56 pushed blob sha256:89732bc7504122601f40269fc9ddfb70982e633ea9caf641ae45736f2846b004
2018/12/05 07:29:56 pushed blob sha256:b6fe600e26aa55dc7ba94228bbe3090aced0298ebaf57853f4c88e11d248e8e3
2018/12/05 07:29:56 knative.registry.svc.cluster.local/knative-training/caching-kaniko/cache:b52d8630301f1f14d786168567c47278f7ff1f25b0c6f1eb199e3304f7e6c6c4: digest: sha256:307e10263a410da19f2b8a892ce5404fe371a70859c2d5fe8e4e2634ae2e03dc size: 423
INFO[0067] Pushing layer knative.registry.svc.cluster.local/knative-training/caching-kaniko/cache:b14bafbd73c266cc29a8bb8ae4e941a74a735b28b93b23a1bdc140c63fc15d8e to cache now 
2018/12/05 07:29:57 pushed blob sha256:ab9e5ac1deebb3046e59ba76879ad7446674d7ac5428043d243ce10652c758f3
2018/12/05 07:29:57 pushed blob sha256:8a7a7644cebf9424dfde43ad37cf7d190ce0515636a33dc8524c08189fe2df69
2018/12/05 07:29:58 knative.registry.svc.cluster.local/knative-training/caching-kaniko/cache:b14bafbd73c266cc29a8bb8ae4e941a74a735b28b93b23a1bdc140c63fc15d8e: digest: sha256:539a505612c34591cdb83c51f1abb309a8b84a9f0cb4f2a00a603dec5dec8b92 size: 424
2018/12/05 07:29:58 pushed blob sha256:8a7a7644cebf9424dfde43ad37cf7d190ce0515636a33dc8524c08189fe2df69
2018/12/05 07:29:58 pushed blob sha256:11224950d73ec5c34608dc73f6e842882bb31ac8fc4da301871dbd6164cd2f8a
2018/12/05 07:29:58 pushed blob sha256:4d6e8a4e0c046d20fba00fcad83817c28134daa77dd29c31d125c3e385464a9c
2018/12/05 07:29:58 pushed blob sha256:90e01955edcd85dac7985b72a8374545eac617ccdddcc992b732e43cd42534af
2018/12/05 07:29:59 knative.registry.svc.cluster.local/knative-training/caching-kaniko:latest: digest: sha256:c269cd927796c785f99dc7c9855927986f5a28957380f9aee1fb6e327cba203a size: 747
```

Second build:

```
$ kubectl logs caching-kaniko-pod-5ee631 -c build-step-build-and-push
INFO[0000] Downloading base image busybox               
ERROR: logging before flag.Parse: E1205 07:30:58.128007       8 metadata.go:142] while reading 'google-dockercfg' metadata: http status code: 404 while fetching url http://metadata.google.internal./computeMetadata/v1/instance/attributes/google-dockercfg
ERROR: logging before flag.Parse: E1205 07:30:58.135734       8 metadata.go:159] while reading 'google-dockercfg-url' metadata: http status code: 404 while fetching url http://metadata.google.internal./computeMetadata/v1/instance/attributes/google-dockercfg-url
2018/12/05 07:30:58 No matching credentials were found, falling back on anonymous
WARN[0001] Error while retrieving image from cache: getting image from path: open /cache/sha256:915f390a8912e16d4beb8689720a17348f3f6d1a7b659697df850ab625ea29d5: no such file or directory 
INFO[0001] Downloading base image busybox               
2018/12/05 07:30:59 No matching credentials were found, falling back on anonymous
INFO[0002] Checking for cached layer knative.registry.svc.cluster.local/knative-training/caching-kaniko/cache:553f18e617d99a4f8025512cb59a5a508c65e9dc3cdd33214c8e74cbd5e8ca48... 
2018/12/05 07:31:00 No matching credentials were found, falling back on anonymous
INFO[0002] Using caching version of cmd: RUN date | tee timestamp1 
INFO[0002] Checking for cached layer knative.registry.svc.cluster.local/knative-training/caching-kaniko/cache:b52d8630301f1f14d786168567c47278f7ff1f25b0c6f1eb199e3304f7e6c6c4... 
2018/12/05 07:31:00 No matching credentials were found, falling back on anonymous
INFO[0002] Using caching version of cmd: RUN sleep 60   
INFO[0002] Checking for cached layer knative.registry.svc.cluster.local/knative-training/caching-kaniko/cache:b14bafbd73c266cc29a8bb8ae4e941a74a735b28b93b23a1bdc140c63fc15d8e... 
2018/12/05 07:31:00 No matching credentials were found, falling back on anonymous
INFO[0002] Using caching version of cmd: RUN date | tee timestamp2 
INFO[0002] Taking snapshot of full filesystem...        
INFO[0002] Skipping paths under /builder/home, as it is a whitelisted directory 
INFO[0002] Skipping paths under /dev, as it is a whitelisted directory 
INFO[0002] Skipping paths under /kaniko, as it is a whitelisted directory 
INFO[0002] Skipping paths under /proc, as it is a whitelisted directory 
INFO[0002] Skipping paths under /sys, as it is a whitelisted directory 
INFO[0002] Skipping paths under /tools, as it is a whitelisted directory 
INFO[0002] Skipping paths under /var/run, as it is a whitelisted directory 
INFO[0002] Skipping paths under /workspace, as it is a whitelisted directory 
INFO[0002] RUN date | tee timestamp1                    
INFO[0002] Found cached layer, extracting to filesystem 
INFO[0002] Taking snapshot of files...                  
INFO[0002] RUN sleep 60                                 
INFO[0002] Found cached layer, extracting to filesystem 
INFO[0003] RUN date | tee timestamp2                    
INFO[0003] Found cached layer, extracting to filesystem 
INFO[0003] Taking snapshot of files...                  
2018/12/05 07:31:01 existing blob: sha256:90e01955edcd85dac7985b72a8374545eac617ccdddcc992b732e43cd42534af
2018/12/05 07:31:01 pushed blob sha256:c49822b80d37d1bf3e81be7f85b15304f1a3b37de1977b6ecdf11662a787dc81
2018/12/05 07:31:02 pushed blob sha256:f86bbdf2fc90c0e2ab9bdd14d443d5227c5c858d4ae3d05d7f269090fae6a8fd
2018/12/05 07:31:02 pushed blob sha256:65f492aeb4b1891946cf4b8f5d06617f1e78058955230b2a4ec1eb2a05e34dda
2018/12/05 07:31:02 knative.registry.svc.cluster.local/knative-training/caching-kaniko:latest: digest: sha256:28161db2b795246767e7267518fc1ea863ff95ca8c0c4d2ded0dd4f06871614d size: 747
```